### PR TITLE
Add banner metadata arg for pages

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -1,4 +1,4 @@
-{% extends "base.html" %}
+{% extends "page.html" %}
 
 {% from "utils.html" import card %}
 
@@ -19,11 +19,13 @@
 {% endmacro %}
 
 
-{% block body %}
+{% block breadcrumbs %}
+{% endblock %}
 
-{{ this.body }}
 
-<div class="container">
+{% block content %}
+
+    {{ this.body }}
 
     {% set columns = 2 %}
     {% for row in this.content|batch(columns) %}
@@ -35,7 +37,5 @@
             {% endfor %}
         </div>
     {% endfor %}
-
-</div>
 
 {% endblock %}

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -1,10 +1,22 @@
 {% extends "base.html" %}
 
+
 {% block title %}
     {{ this.title }} | {{ site.name }}
 {% endblock %}
 
+
 {% block body %}
+
+
+{% block banner %}
+    {% if this.banner is defined %}
+        <div class="container-fluid">
+            <div class="banner" style="background-image: url(/images/{{this.banner}});">
+            </div>
+        </div>
+    {% endif %}
+{% endblock %}
 
 <div class="container">
 
@@ -18,9 +30,9 @@
         </ol>
     {% endblock %}
 
-    <h1>{{ this.title }}</h1>
-
     {% block content %}
+
+        <h1>{{ this.title }}</h1>
 
         {{ this.body }}
 

--- a/_layouts/publication.html
+++ b/_layouts/publication.html
@@ -1,7 +1,11 @@
 {% extends "page.html" %}
 {% from "utils.html" import fa, ai %}
 
+
 {% block content %}
+
+
+<h1>{{ this.title }}</h1>
 
 {% if this.author is defined %}
     <p class="pub-date-author">
@@ -193,5 +197,6 @@
         {% endblock %}
     </div>
 </div>
+
 
 {% endblock %}

--- a/_site.yml
+++ b/_site.yml
@@ -14,8 +14,6 @@ language: en
 
 keywords: 'science, geoscience, geophysics, software, open-source'
 
-banner: '/images/torres-del-paine.jpg'
-
 menulinks: [
     ['/about', 'About'],
     #['/research', 'Research'],

--- a/index.md
+++ b/index.md
@@ -6,26 +6,15 @@ content:
     - talks
     - teaching
     - software
+banner: torres-del-paine.jpg
 ---
 
-<div class="container-fluid">
-
-    <div class="banner" style="background-image: url({{site.banner}});">
-    </div>
-
-    <div class="container">
-
-        <p class="site-description text-center">
-        I teach geophysics.
-        I program.
-        I research gravimetry and inverse problems.
-        </br>
-        Learning should be active.
-        Software should be free.
-        Science should be open.
-        </p>
-
-    </div>
-
-</div>
-
+<p class="site-description text-center">
+I teach geophysics.
+I program.
+I research gravimetry and inverse problems.
+</br>
+Learning should be active.
+Software should be free.
+Science should be open.
+</p>


### PR DESCRIPTION
Make the banner image in the homepage optional for every page to define
in its metadata. Might be useful for blogposts or other pages. Had to
move things from index.md to the page.html template and switch around
some other parts of the template.