### PR TITLE
No left-right padding for the site description

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -144,7 +144,7 @@ img {
 
 .site-description {
     margin: 0px;
-    padding: 50px 20px;
+    padding: 50px 0px;
     line-height: 60px;
     font-size: 34px;
     font-weight: 300;


### PR DESCRIPTION
It doesn't make much of a difference on desktop but in smaller screens
it looks more in place with the rest of the page