### PR TITLE
Refactor the template to reuse components

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,8 @@ before_install:
   - export PATH=/home/travis/miniconda3/bin:$PATH
   # Update conda itself
   - conda update --yes conda
+  # Temporary patch for conda env (see https://github.com/conda/conda/issues/3738)
+  - conda install --yes pyyaml
 
 install:
   - conda env create

--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -11,7 +11,7 @@
             <meta name="keywords" content="{{ site.keywords }}"/>
         {% endif %}
     {% endblock %}
-    <title>{% block title %}{{ site.name }}{% endblock title %}</title>
+    <title>{% block title %}{{ site.title }}{% endblock title %}</title>
     <link rel="shortcut icon" href="/images/favicon.png">
     <link rel="stylesheet" href="/css/bootstrap.min.css">
     <link rel="stylesheet" href="/css/style.css">

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -15,7 +15,6 @@
             </div>
         {% endfor %}
     </div>
-
 {% endmacro %}
 
 
@@ -23,9 +22,16 @@
 {% endblock %}
 
 
+{% block title %}
+    {{this.title}}
+{% endblock %}
+
+
 {% block content %}
 
-    {{ this.body }}
+    <p class="site-description text-center">
+        {{site.description}}
+    </p>
 
     {% set columns = 2 %}
     {% for row in this.content|batch(columns) %}
@@ -37,5 +43,7 @@
             {% endfor %}
         </div>
     {% endfor %}
+
+    {{ this.body }}
 
 {% endblock %}

--- a/_layouts/nav.html
+++ b/_layouts/nav.html
@@ -1,6 +1,6 @@
 <div class="container-fluid menu text-center">
     <div class="col-lg-3 menu-brand">
-        <a href="/">{{ site.title }}</a>
+        <a href="/">{{ site.brand }}</a>
     </div>
     <div class="col-lg-9 menu-list">
         <ul>

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -2,7 +2,7 @@
 
 
 {% block title %}
-    {{ this.title }} | {{ site.name }}
+    {{ this.title }} | {{ site.title }}
 {% endblock %}
 
 

--- a/_layouts/publication.html
+++ b/_layouts/publication.html
@@ -1,5 +1,5 @@
 {% extends "page.html" %}
-{% from "utils.html" import fa, ai, get_authors, pub_alerts, pub_info %}
+{% from "utils.html" import fa, ai, get_authors, pub_alerts, pub_info, show_alm %}
 
 
 {% block content %}
@@ -27,19 +27,8 @@
 
         {{ pub_info(this, fancy=true) }}
 
-        {% if this.alm is defined and this.alm %}
-            <h2>Article Level Metrics</h2>
-            {% if this.doi %}
-                <h3>Main article</h3>
-                <div data-badge-details="right" data-badge-type="medium-donut"
-                 data-doi="{{this.doi}}" class="altmetric-embed"></div>
-            {% endif %}
-            {% if this.supplement is defined %}
-                <h3>Data/Supplement</h3>
-                <div data-badge-details="right" data-badge-type="medium-donut"
-                 data-doi="{{this.supplement}}" class="altmetric-embed"></div>
-            {% endif %}
-        {% endif %}
+        {{ show_alm(this) }}
+
         {% if this.citation is defined %}
             <h2>Citation</h2>
             <p>{{this.citation}}</p>

--- a/_layouts/publication.html
+++ b/_layouts/publication.html
@@ -1,25 +1,17 @@
 {% extends "page.html" %}
-{% from "utils.html" import fa, ai %}
+{% from "utils.html" import fa, ai, get_authors %}
 
 
 {% block content %}
-
 
 <h1>{{ this.title }}</h1>
 
 {% if this.author is defined %}
     <p class="pub-date-author">
-        by
-        {% for author in this.author.split(', ') %}
-            {% if author == "uieda" %}
-                <strong>{{ site.author }}</strong>{% if not loop.last %}, {% endif%}
-            {% else %}
-                {{ site.authors[author] }}{% if not loop.last %}, {% endif%}
-            {% endif %}
-        {% endfor %}
-    {% if this.date is defined %}
-        ({{ this.date.year }})
-    {% endif %}
+        by {{ get_authors(this, site) }}
+        {% if this.date is defined %}
+            ({{ this.date.year }})
+        {% endif %}
     </p>
 {% endif %}
 

--- a/_layouts/publication.html
+++ b/_layouts/publication.html
@@ -1,5 +1,5 @@
 {% extends "page.html" %}
-{% from "utils.html" import fa, ai, get_authors, pub_alerts %}
+{% from "utils.html" import fa, ai, get_authors, pub_alerts, pub_info %}
 
 
 {% block content %}
@@ -15,7 +15,7 @@
     </p>
 {% endif %}
 
-{{ pub_alerts(this) }}
+{{ pub_alerts(this, fancy=true) }}
 
 <div class="row">
     <div class="col-md-4">
@@ -25,119 +25,8 @@
                  src="/images/thumb/{{this.thumbnail}}"></img>
         {% endif %}
 
-        <h2>Info</h2>
+        {{ pub_info(this, fancy=true) }}
 
-        <ul class="list-group">
-            {% block left %}
-                {% if this.oa is defined and this.oa %}
-                    <li class="list-group-item active">
-                        {{ ai("open-access", "fa-fw", "Open-access article") }}
-                        Open-Access
-                    </li>
-                {% endif %}
-                {% if this.journal is defined %}
-                    <li class="list-group-item">
-                        {{ fa("book", "fa-fw", "Journal name") }}
-                        Journal: {{this.journal}}
-                    </li>
-                {% endif %}
-                {% if this.presentation is defined %}
-                    <li class="list-group-item">
-                        {{ fa("comments-o", "fa-fw", "Presentation type") }}
-                        {{this.presentation|capitalize()}} presentation
-                    </li>
-                {% endif %}
-                {% if this.event is defined %}
-                    <li class="list-group-item">
-                        {{ fa("users", "fa-fw", "Event name") }}
-                        {{this.event}}
-                    </li>
-                {% endif %}
-                {% if this.institution is defined %}
-                    <li class="list-group-item">
-                        {{ fa("university", "fa-fw", "Institution name") }}
-                        {{this.institution}}
-                    </li>
-                {% endif %}
-                {% if this.course is defined %}
-                    <li class="list-group-item">
-                        {{ fa("graduation-cap", "fa-fw", "Course type") }}
-                        {{ this.course|capitalize() }} course
-                    </li>
-                {% endif %}
-                {% if this.language is defined %}
-                    <li class="list-group-item">
-                        {{ fa("code", "fa-fw", "Programming language") }}
-                        Language:
-                        {{this.language}}
-                    </li>
-                {% endif %}
-                {% if this.license is defined %}
-                    <li class="list-group-item">
-                        {{ fa("file-text", "fa-fw", "Open-source license") }}
-                        {{this.license}}
-                        License
-                    </li>
-                {% endif %}
-                {% if this.slides is defined %}
-                    <li class="list-group-item">
-                        {{ fa("desktop", "fa-fw", "Download slides") }}
-                        Slides:
-                        {% if this.slides[:4] == "http" %}
-                            <a href="{{this.slides}}">{{this.slides}}</a>
-                        {% else %}
-                            <a href="http://dx.doi.org/{{this.slides}}">{{this.slides}}</a>
-                        {% endif %}
-                    </li>
-                {% endif %}
-                {% if this.poster is defined %}
-                    <li class="list-group-item">
-                        {{ fa("picture-o", "fa-fw", "Download poster") }}
-                        Poster:
-                        {% if this.poster[:4] == "http" %}
-                            <a href="{{this.poster}}">{{this.poster}}</a>
-                        {% else %}
-                            <a href="http://dx.doi.org/{{this.poster}}">{{this.poster}}</a>
-                        {% endif %}
-                    </li>
-                {% endif %}
-                {% if this.repository is defined %}
-                    <li class="list-group-item">
-                        {{ fa("github-square", "fa-fw", "Github repository") }}
-                        Source code:
-                        <a href="https://github.com/{{this.repository}}">{{
-                            this.repository}}</a>
-                    </li>
-                {% endif %}
-                {% if this.supplement is defined %}
-                    <li class="list-group-item">
-                        {{ fa("paperclip", "fa-fw", "Supplementary material") }}
-                        Data/Supplement:
-                        <a href="http://dx.doi.org/{{this.supplement}}">{{this.supplement}}</a>
-                    </li>
-                {% endif %}
-                {% if this.pdf is defined %}
-                    <li class="list-group-item">
-                        {{ fa("file-pdf-o", "fa-fw", "Paper PDF") }}
-                        PDF:
-                        <a href="/pdf/{{this.pdf}}">{{this.pdf}}</a>
-                    </li>
-                {% endif %}
-                {% if this.doi is defined %}
-                    <li class="list-group-item">
-                        {{ fa("external-link", "fa-fw", "DOI link to publisher") }}
-                        doi: <a href="http://dx.doi.org/{{this.doi}}">{{
-                            this.doi}}</a>
-                    </li>
-                {% endif %}
-                {% if this.website is defined %}
-                    <li class="list-group-item">
-                        {{ fa("home", "fa-fw", "Website") }}
-                        <a href="{{this.website}}">{{this.website}}</a>
-                    </li>
-                {% endif %}
-            {% endblock %}
-        </ul>
         {% if this.alm is defined and this.alm %}
             <h2>Article Level Metrics</h2>
             {% if this.doi %}

--- a/_layouts/publication.html
+++ b/_layouts/publication.html
@@ -1,5 +1,5 @@
 {% extends "page.html" %}
-{% from "utils.html" import fa, ai, get_authors %}
+{% from "utils.html" import fa, ai, get_authors, pub_alerts %}
 
 
 {% block content %}
@@ -15,33 +15,7 @@
     </p>
 {% endif %}
 
-{% if this.inreview is defined and this.inreview %}
-    <div class="alert alert-warning">
-        <strong>
-        This article is unpublished and is currently undergoing
-        peer-review.
-        </strong>
-    </div>
-{% endif %}
-
-{% if this.accepted is defined and this.accepted %}
-    <div class="alert alert-info alert-blue">
-        This article has been <strong>accepted</strong> for publication
-        {% if this.journal is defined %}
-            in {{this.journal}}
-        {% endif %}
-        but has not yet been published.
-    </div>
-{% endif %}
-
-{% if this.inprogress is defined and this.inprogress %}
-    <div class="alert alert-info alert-blue">
-        {{ fa("refresh", "fa-fw", "Course in progress") }}
-        This course is currently <strong>in progress</strong>
-        for the {{this.date.year}} school year.
-    </div>
-{% endif %}
-
+{{ pub_alerts(this) }}
 
 <div class="row">
     <div class="col-md-4">

--- a/_layouts/publication.html
+++ b/_layouts/publication.html
@@ -179,7 +179,7 @@
                 <div data-badge-details="right" data-badge-type="medium-donut"
                  data-doi="{{this.doi}}" class="altmetric-embed"></div>
             {% endif %}
-            {% if this.supplement %}
+            {% if this.supplement is defined %}
                 <h3>Data/Supplement</h3>
                 <div data-badge-details="right" data-badge-type="medium-donut"
                  data-doi="{{this.supplement}}" class="altmetric-embed"></div>

--- a/_layouts/utils.html
+++ b/_layouts/utils.html
@@ -104,3 +104,126 @@
         {% endif %}
     {% endif %}
 {% endmacro %}
+
+
+{% macro pub_info(article, fancy=true) %}
+    <h2>Info</h2>
+
+    {% if fancy %}
+        {% set ul_class = "list-group" %}
+        {% set li_class = "list-group-item" %}
+    {% else %}
+        {% set ul_class = "" %}
+        {% set li_class = "" %}
+    {% endif %}
+
+    <ul class={{ ul_class }}>
+        {% if article.oa is defined and article.oa %}
+            <li class={{ li_class }}>
+                {% if fancy %}{{ ai("open-access", "fa-fw", "Open-access article") }}{% endif %}
+                Open-Access
+            </li>
+        {% endif %}
+        {% if article.journal is defined %}
+            <li class={{ li_class }}>
+                {% if fancy %}{{ fa("book", "fa-fw", "Journal name") }}{% endif %}
+                Journal: <em>{{article.journal}}</em>
+            </li>
+        {% endif %}
+        {% if article.presentation is defined %}
+            <li class={{ li_class }}>
+                {% if fancy %}{{ fa("comments-o", "fa-fw", "Presentation type") }}{% endif %}
+                {{article.presentation|capitalize()}} presentation
+            </li>
+        {% endif %}
+        {% if article.event is defined %}
+            <li class={{ li_class }}>
+                {% if fancy %}{{ fa("users", "fa-fw", "Event name") }}{% endif %}
+                {{article.event}}
+            </li>
+        {% endif %}
+        {% if article.institution is defined %}
+            <li class={{ li_class }}>
+                {% if fancy %}{{ fa("university", "fa-fw", "Institution name") }}{% endif %}
+                {{article.institution}}
+            </li>
+        {% endif %}
+        {% if article.course is defined %}
+            <li class={{ li_class }}>
+                {% if fancy %}{{ fa("graduation-cap", "fa-fw", "Course type") }}{% endif %}
+                {{ article.course|capitalize() }} course
+            </li>
+        {% endif %}
+        {% if article.language is defined %}
+            <li class={{ li_class }}>
+                {% if fancy %}{{ fa("code", "fa-fw", "Programming language") }}{% endif %}
+                Language:
+                {{article.language}}
+            </li>
+        {% endif %}
+        {% if article.license is defined %}
+            <li class={{ li_class }}>
+                {% if fancy %}{{ fa("file-text", "fa-fw", "Open-source license") }}{% endif %}
+                {{article.license}}
+                License
+            </li>
+        {% endif %}
+        {% if article.slides is defined %}
+            <li class={{ li_class }}>
+                {% if fancy %}{{ fa("desktop", "fa-fw", "Download slides") }}{% endif %}
+                Slides:
+                {% if article.slides[:4] == "http" %}
+                    <a href="{{article.slides}}">{{article.slides}}</a>
+                {% else %}
+                    <a href="http://dx.doi.org/{{article.slides}}">{{article.slides}}</a>
+                {% endif %}
+            </li>
+        {% endif %}
+        {% if article.poster is defined %}
+            <li class={{ li_class }}>
+                {% if fancy %}{{ fa("picture-o", "fa-fw", "Download poster") }}{% endif %}
+                Poster:
+                {% if article.poster[:4] == "http" %}
+                    <a href="{{article.poster}}">{{article.poster}}</a>
+                {% else %}
+                    <a href="http://dx.doi.org/{{article.poster}}">{{article.poster}}</a>
+                {% endif %}
+            </li>
+        {% endif %}
+        {% if article.repository is defined %}
+            <li class={{ li_class }}>
+                {% if fancy %}{{ fa("github-square", "fa-fw", "Github repository") }}{% endif %}
+                Source code:
+                <a href="https://github.com/{{article.repository}}">{{
+                    article.repository}}</a>
+            </li>
+        {% endif %}
+        {% if article.supplement is defined %}
+            <li class={{ li_class }}>
+                {% if fancy %}{{ fa("paperclip", "fa-fw", "Supplementary material") }}{% endif %}
+                Data/Supplement:
+                <a href="http://dx.doi.org/{{article.supplement}}">{{article.supplement}}</a>
+            </li>
+        {% endif %}
+        {% if article.pdf is defined %}
+            <li class={{ li_class }}>
+                {% if fancy %}{{ fa("file-pdf-o", "fa-fw", "Paper PDF") }}{% endif %}
+                PDF:
+                <a href="/pdf/{{article.pdf}}">{{article.pdf}}</a>
+            </li>
+        {% endif %}
+        {% if article.doi is defined %}
+            <li class={{ li_class }}>
+                {% if fancy %}{{ fa("external-link", "fa-fw", "DOI link to publisher") }}{% endif %}
+                doi: <a href="http://dx.doi.org/{{article.doi}}">{{
+                    article.doi}}</a>
+            </li>
+        {% endif %}
+        {% if article.website is defined %}
+            <li class={{ li_class }}>
+                {% if fancy %}{{ fa("home", "fa-fw", "Website") }}{% endif %}
+                <a href="{{article.website}}">{{article.website}}</a>
+            </li>
+        {% endif %}
+    </ul>
+{% endmacro %}

--- a/_layouts/utils.html
+++ b/_layouts/utils.html
@@ -1,12 +1,15 @@
 {# Utility functions for the templates #}
 
+
 {% macro fa(name, class='', title='') %}
     <i class="fa fa-{{ name }} {{ class }}" title="{{ title }}"></i>
 {% endmacro %}
 
+
 {% macro ai(name, class='', title='') %}
     <i class="ai ai-{{ name }} {{ class }}" title="{{ title }}"></i>
 {% endmacro %}
+
 
 {% macro card(page, date=true, show_oa=false, inprogress=false) %}
 <a href="{{ page.url }}">
@@ -38,6 +41,7 @@
     </div></a>
 {% endmacro %}
 
+
 {% macro get_authors(article, site) %}
     {% for author in article.author.split(', ') %}
         {% if author == site.author %}
@@ -47,4 +51,56 @@
         {% endif %}
         {{ author_name }}{% if not loop.last %}, {% endif %}
     {% endfor %}
+{% endmacro %}
+
+
+{% macro pub_alerts(article, fancy=true) %}
+    {% if article.inreview is defined and article.inreview %}
+        {% if fancy %}
+            <div class="alert alert-warning">
+        {% else %}
+            <p>
+        {% endif %}
+            This article is unpublished and is currently
+            <strong>undergoing peer-review</strong>.
+        {% if fancy %}
+            </div>
+        {% else %}
+            </p>
+        {% endif %}
+    {% endif %}
+
+    {% if article.accepted is defined and article.accepted %}
+        {% if fancy %}
+            <div class="alert alert-info alert-blue">
+        {% else %}
+            <p>
+        {% endif %}
+            This article has been <strong>accepted</strong> for publication
+            {% if article.journal is defined %}
+                in {{article.journal}}
+            {% endif %}
+            but has not yet been published.
+        {% if fancy %}
+            </div>
+        {% else %}
+            </p>
+        {% endif %}
+    {% endif %}
+
+    {% if article.inprogress is defined and article.inprogress %}
+        {% if fancy %}
+            <div class="alert alert-info alert-blue">
+            {{ fa("refresh", "fa-fw", "Course in progress") }}
+        {% else %}
+            <p>
+        {% endif %}
+            This course is currently <strong>in progress</strong>
+            for the {{article.date.year}} school year.
+        {% if fancy %}
+            </div>
+        {% else %}
+            </p>
+        {% endif %}
+    {% endif %}
 {% endmacro %}

--- a/_layouts/utils.html
+++ b/_layouts/utils.html
@@ -37,3 +37,14 @@
         </div>
     </div></a>
 {% endmacro %}
+
+{% macro get_authors(article, site) %}
+    {% for author in article.author.split(', ') %}
+        {% if author == site.author %}
+            {% set author_name = "<strong>" + site.authors[author] + "</strong>" %}
+        {% else %}
+            {% set author_name = site.authors[author] %}
+        {% endif %}
+        {{ author_name }}{% if not loop.last %}, {% endif %}
+    {% endfor %}
+{% endmacro %}

--- a/_layouts/utils.html
+++ b/_layouts/utils.html
@@ -227,3 +227,22 @@
         {% endif %}
     </ul>
 {% endmacro %}
+
+
+{% macro show_alm(article) %}
+    {% if article.alm is defined and article.alm %}
+        <h2>Article Level Metrics</h2>
+
+        {% if article.doi is defined %}
+            <h3>Main article</h3>
+            <div data-badge-details="right" data-badge-type="medium-donut"
+             data-doi="{{article.doi}}" class="altmetric-embed"></div>
+        {% endif %}
+
+        {% if article.supplement is defined %}
+            <h3>Data/Supplement</h3>
+            <div data-badge-details="right" data-badge-type="medium-donut"
+             data-doi="{{article.supplement}}" class="altmetric-embed"></div>
+        {% endif %}
+    {% endif %}
+{% endmacro %}

--- a/_site.yml
+++ b/_site.yml
@@ -25,7 +25,7 @@ menulinks: [
     ['/teaching', 'Teaching'],
     ['/software', 'Software'],
     ['/contact', 'Contact'],
-    ['http://www.pinga-lab.org', 'PINGA lab'],
+    ['http://www.pinga-lab.org', 'PINGA-lab'],
     ['https://github.com/leouieda',
      '<i class="fa fa-github fa-lg" title="Github"></i>'],
     ['https://twitter.com/leouieda',

--- a/_site.yml
+++ b/_site.yml
@@ -1,6 +1,8 @@
-name: Leonardo Uieda
+title: Leonardo Uieda
 
-title: "LEONARDO <strong>UIEDA</strong>"
+brand: "LEONARDO <strong>UIEDA</strong>"
+
+description: "I teach geophysics. I program. I research gravimetry and inverse problems. </br>Learning should be active. Software should be free. Science should be open."
 
 author: Leonardo Uieda
 

--- a/_site.yml
+++ b/_site.yml
@@ -4,7 +4,7 @@ brand: "LEONARDO <strong>UIEDA</strong>"
 
 description: "I teach geophysics. I program. I research gravimetry and inverse problems. </br>Learning should be active. Software should be free. Science should be open."
 
-author: Leonardo Uieda
+author: uieda
 
 keep_files: [".nojekyll"]
 
@@ -33,6 +33,7 @@ menulinks: [
     ]
 
 authors:
+    uieda: Leonardo Uieda
     barbosa: Valéria C. F. Barbosa
     carla: Carla Braitenberg
     melo: Felipe F. Melo

--- a/index.md
+++ b/index.md
@@ -9,13 +9,3 @@ content:
 banner: torres-del-paine.jpg
 banner_position: left
 ---
-
-<p class="site-description text-center">
-I teach geophysics.
-I program.
-I research gravimetry and inverse problems.
-</br>
-Learning should be active.
-Software should be free.
-Science should be open.
-</p>


### PR DESCRIPTION
Moves a portion of the template constructs to macros so that they can be accessed from other templates (particularly the side bar for publications). This will pave the way for the RSS feeds (#36).


