### PR TITLE
Get full name from authors dict in author metadata

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -6,7 +6,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1">
     {% block meta %}
-        <meta name="author" content="{{ site.author }}"/>
+        <meta name="author" content="{{ site.authors[site.author] }}"/>
         {% if site.keywords %}
             <meta name="keywords" content="{{ site.keywords }}"/>
         {% endif %}


### PR DESCRIPTION
The `author` HTML metadata was using just `site.author` when it should
be `site.authors[site.author]` after the recent template refactoring.