### PR TITLE
Add comments icon and replace github repo icon

### DIFF
--- a/_layouts/utils.html
+++ b/_layouts/utils.html
@@ -187,14 +187,14 @@
         {% endif %}
         {% if article.language is defined %}
             <li class={{ li_class }}>
-                {% if fancy %}{{ fa("code", "fa-fw", "Programming language") }}{% endif %}
+                {% if fancy %}{{ fa("flag", "fa-fw", "Programming language") }}{% endif %}
                 Language:
                 {{article.language}}
             </li>
         {% endif %}
         {% if article.license is defined %}
             <li class={{ li_class }}>
-                {% if fancy %}{{ fa("file-text", "fa-fw", "Open-source license") }}{% endif %}
+                {% if fancy %}{{ fa("gavel", "fa-fw", "Open-source license") }}{% endif %}
                 {{article.license}}
                 License
             </li>
@@ -223,7 +223,7 @@
         {% endif %}
         {% if article.repository is defined %}
             <li class={{ li_class }}>
-                {% if fancy %}{{ fa("github-square", "fa-fw", "Github repository") }}{% endif %}
+                {% if fancy %}{{ fa("code", "fa-fw", "Source code repository") }}{% endif %}
                 Source code:
                 <a href="https://github.com/{{article.repository}}">{{
                     article.repository}}</a>
@@ -284,6 +284,7 @@
     {% if fancy %}
     <div class="panel panel-default">
         <div class="panel-body">
+            {{ fa("comments", "fa-fw") }}
     {% endif %}
             <strong>Comments?</strong>
             Let me know on Twitter

--- a/about/index.md
+++ b/about/index.md
@@ -52,8 +52,7 @@ teaching material
 (code, data, slides, etc)
 online under permissive licenses.
 You'll find links to source code, images, lessons, etc, around this
-website
-(look for the {{fa("github-square", "fa-fw")}} icon).
+website.
 </p>
 
 </div>

--- a/papers/index.md
+++ b/papers/index.md
@@ -11,6 +11,6 @@ Publications marked with a {{ai("open-access")}} are
 [open-access (OA)](https://en.wikipedia.org/wiki/Open_access).
 I have made available links for you to download free PDFs from all non-OA
 publications.
-Many papers include links to accompanying source-code repositories on
-Github ({{fa("github-square")}}) and supplementary material
-hosted on [figshare](http://figshare.com) or [Zenodo](http://zenodo.org).
+Many papers include links to accompanying source-code repositories and
+supplementary material hosted on [figshare](http://figshare.com) or
+[Zenodo](http://zenodo.org).

--- a/talks/index.md
+++ b/talks/index.md
@@ -9,4 +9,4 @@ reverse: true
 
 A list of oral and poster presentations I have given over the years.  All have
 links to download the poster/slides.  Most include links to source-code and
-data used to produce the results (look for the {{fa("github-square")}} icon).
+data used to produce the results.


### PR DESCRIPTION
Swapped around some icons because the square github icon doesn't really
work in small sizes. Using the </> icon now and changed some others to
accommodate. Removed mentions of the icon from the text.