### PR TITLE
Update links to swung and centralize in _site.yml

### DIFF
--- a/_layouts/utils.html
+++ b/_layouts/utils.html
@@ -313,7 +313,7 @@
             <strong>Comments?</strong>
             Let me know on Twitter
             <a href="https://twitter.com/intent/tweet?text=@{{ site.twitter }}&url={{ site.url}}{{ post.url }}">@{{ site.twitter }}</a>
-            or in the <a href="http://swung.rocks/">Software Underground</a>
+            or in the <a href="{{ site.reflinks.swung.url }}">{{ site.reflinks.swung.title }}</a>
             Slack group.
     {% if fancy %}
         </div>

--- a/_site.yml
+++ b/_site.yml
@@ -68,3 +68,6 @@ reflinks:
     site_repo:
         url: https://github.com/leouieda/website
         title: leouieda/website
+    swung:
+        url: https://softwareunderground.org
+        title: Software Underground

--- a/contact/index.md
+++ b/contact/index.md
@@ -21,12 +21,11 @@ The best way to get in touch is to write me an e-mail or ping me on Twitter:
 
 <p>
 I'm also fairly active on the
-<a href="http://www.agilegeoscience.com/blog/2016/8/04/the-sound-of-the-software-underground">Software Underground</a>
+<a href="{{ site.reflinks.swung.url }}">{{ site.reflinks.swung.title }}</a>
 Slack channel.
 It's a place where very interesting and smart geoscientists gather to chat and
 exchange ideas.
-I highly recommend signing up (for free) at
-<a href="http://swung.rocks/">swung.rocks</a>.
+I highly recommend signing up (it's free!).
 </p>
 
 If you're around Rio and want to chat about geophysics, science, free software,


### PR DESCRIPTION
The old swung.rocks seems to be broken. Update to the new
softwareunderground.org and move all references to a reflink in
_site.yml to make it easier to update in the future.