### PR TITLE
Allow html in "slides" and "poster" header tags

### DIFF
--- a/_layouts/utils.html
+++ b/_layouts/utils.html
@@ -221,6 +221,8 @@
                 Slides:
                 {% if article.slides[:4] == "http" %}
                     <a href="{{article.slides}}">{{article.slides}}</a>
+                {% elif "<a " in article.slides and "</a>" in article.slides %}
+                    {{article.slides}}
                 {% else %}
                     <a href="http://dx.doi.org/{{article.slides}}">{{article.slides}}</a>
                 {% endif %}
@@ -232,6 +234,8 @@
                 Poster:
                 {% if article.poster[:4] == "http" %}
                     <a href="{{article.poster}}">{{article.poster}}</a>
+                {% elif "<a " in article.poster and "</a>" in article.poster %}
+                    {{article.poster}}
                 {% else %}
                     <a href="http://dx.doi.org/{{article.poster}}">{{article.poster}}</a>
                 {% endif %}
@@ -241,8 +245,11 @@
             <li class={{ li_class }}>
                 {% if fancy %}{{ fa("code", "fa-fw", "Source code repository") }}{% endif %}
                 Source code:
-                <a href="https://github.com/{{article.repository}}">{{
-                    article.repository}}</a>
+                {% if "<a " in article.repository and "</a>" in article.repository %}
+                    {{article.repository}}
+                {% else %}
+                    <a href="https://github.com/{{article.repository}}">{{ article.repository }}</a>
+                {% endif %}
             </li>
         {% endif %}
         {% if article.supplement is defined %}

--- a/talks/agu-cancun2013.md
+++ b/talks/agu-cancun2013.md
@@ -3,7 +3,6 @@ title: 3D magnetic inversion by planting anomalous densities
 author: uieda, barbosa
 date: 2013-05-01
 repository: leouieda/agu-cancun2013
-presentation: oral
 doi: 10.6084/m9.figshare.703651
 slides: 10.6084/m9.figshare.703651
 event: AGU Meeting of the Americas

--- a/talks/agu2010.md
+++ b/talks/agu2010.md
@@ -6,7 +6,6 @@ event: AGU Meeting of the Americas
 repository: leouieda/agu2010
 slides: 10.6084/m9.figshare.156858
 doi: 10.6084/m9.figshare.156858
-presentation: oral
 thumbnail: agu2010.png
 alm: true
 layout: publication

--- a/talks/egu2014.md
+++ b/talks/egu2014.md
@@ -6,7 +6,6 @@ event: EGU General Assembly
 slides: 10.6084/m9.figshare.1155457
 doi: 10.6084/m9.figshare.1155457
 repository: leouieda/egu2014
-presentation: oral
 thumbnail: egu2014.png
 alm: true
 layout: publication

--- a/talks/gghs2012.md
+++ b/talks/gghs2012.md
@@ -3,7 +3,6 @@ title: Rapid 3D inversion of gravity and gravity gradient data to test geologic 
 author: uieda, barbosa
 date: 2012-10-15
 repository: leouieda/gghs2012
-presentation: oral
 slides: 10.6084/m9.figshare.156859
 doi: 10.6084/m9.figshare.156859
 event: International Symposium on Gravity, Geoid and Height Systems

--- a/talks/iag-04-2015.md
+++ b/talks/iag-04-2015.md
@@ -7,7 +7,6 @@ event: Seminários do Departamento de Geofísica
 slides: 10.6084/m9.figshare.1381870
 doi: 10.6084/m9.figshare.1381870
 repository: leouieda/iag-04-2015
-presentation: oral
 thumbnail: iag-04-2015.png
 alm: true
 layout: publication

--- a/talks/sbgf2011.md
+++ b/talks/sbgf2011.md
@@ -4,7 +4,6 @@ author: uieda, barbosa
 date: 2011-08-01
 pdf: sbgf-2011.pdf
 repository: leouieda/sbgf2011
-presentation: oral
 slides: 10.6084/m9.figshare.156861
 event: Internation Congress of the Brazilian Geophysical Society
 doi: 10.1190/sbgf2011-179

--- a/talks/scipy2013.md
+++ b/talks/scipy2013.md
@@ -4,7 +4,7 @@ author: uieda, oliveira-jr, barbosa
 date: 2013-06-01
 pdf: scipy-2013.pdf
 repository: leouieda/scipy2013
-presentation: oral
+slides: <a href="http://www.leouieda.com/scipy2013/?theme=night#/">HTML slides</a>
 event: 12th Python in Science Conference
 doi: 10.6084/m9.figshare.708390
 thumbnail: scipy2013.png
@@ -14,9 +14,6 @@ layout: publication
 ---
 
 # Presentation
-
-**Slides are available in HTML**:
-[leouieda.com/scipy2013](http://www.leouieda.com/scipy2013/?theme=night#/)
 
 <div class="embed-responsive embed-responsive-16by9">
 <iframe width="560" height="315"

--- a/talks/seg-carlos2012.md
+++ b/talks/seg-carlos2012.md
@@ -4,7 +4,6 @@ author: carlos, uieda, yli, barbosa, mbraga, angeli, peres
 date: 2012-11-01
 pdf: seg-carlos-2012.pdf
 repository: leouieda/seg2012
-presentation: oral
 slides: 10.6084/m9.figshare.156865
 event: SEG Annual Meeting
 doi: 10.1190/segam2012-0525.1

--- a/talks/seg2011.md
+++ b/talks/seg2011.md
@@ -4,7 +4,6 @@ author: uieda, barbosa
 date: 2011-09-01
 pdf: seg-2011.pdf
 repository: leouieda/seg2011
-presentation: oral
 slides: 10.6084/m9.figshare.156863
 event: SEG Annual Meeting
 doi: 10.1190/1.3628201

--- a/talks/seg2012.md
+++ b/talks/seg2012.md
@@ -4,7 +4,6 @@ author: uieda, barbosa
 date: 2012-11-01
 pdf: seg-2012.pdf
 repository: leouieda/seg2012
-presentation: oral
 slides: 10.6084/m9.figshare.156864
 event: SEG Annual Meeting
 doi: 10.1190/segam2012-0383.1

--- a/talks/tgif-2017.md
+++ b/talks/tgif-2017.md
@@ -6,7 +6,6 @@ institution: University of Hawaii at Manoa
 event: TGIF Seminar
 repository: leouieda/tgif-2017
 license: Creative Commons Attribution
-presentation: oral
 slides: 10.6084/m9.figshare.4779766
 doi: 10.6084/m9.figshare.4779766
 thumbnail: tgif-2017.png


### PR DESCRIPTION
If an HTML link (using "<a" and "</a>") is given in "slides", "poster",
or "repository", will insert that in the info bar. Allows inserting HTML
slides that aren't on figshare.