### PR TITLE
Remove thesis title from page titles

### DIFF
--- a/_layouts/about.html
+++ b/_layouts/about.html
@@ -12,7 +12,7 @@
 <div class="row">
 {% for edu in this.content %}
     <div class="col-md-4">
-    <h3><a href="{{ edu.url }}"><b>{{ edu.degree }}</b> in {{ edu.subject }}  »</a></h3>
+    <h3><a href="{{ edu.url }}">{{ edu.title }}  »</a></h3>
     <ul class="fa-ul">
         <li><i class="fa-li fa fa-calendar fa-fw"></i>
             {{ edu.start_date.year}}-{{ edu.date.year }}
@@ -24,7 +24,7 @@
             Advisor: {{ edu.advisor }}
         </li>
         <li><i class="fa-li fa fa-book fa-fw"></i>
-            Thesis: {{ edu.title }}
+            Thesis: {{ edu.thesis }}
         </li>
     </ul>
     </div>

--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -20,7 +20,7 @@
         {% endblock %}
     {% endblock %}
 
-    <title>{% block title %}{{ site.title }}{% endblock title %}</title>
+    <title>{% block title %}{{ site.title|striptags }}{% endblock title %}</title>
     <link rel="shortcut icon" href="/images/favicon.png">
     <link rel="stylesheet" href="/css/bootstrap.min.css">
     <link rel="stylesheet" href="/css/style.css">

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -35,7 +35,7 @@
 
 
 {% block title %}
-    {{ this.title }} | {{ site.title }}
+    {{ this.title|striptags }} | {{ site.title|striptags }}
 {% endblock %}
 
 

--- a/_layouts/utils.html
+++ b/_layouts/utils.html
@@ -211,10 +211,23 @@
                 {{article.institution}}
             </li>
         {% endif %}
+        {% if article.thesis is defined %}
+            <li class={{ li_class }}>
+                {% if fancy %}{{ fa("book", "fa-fw", "Thesis title") }}{% endif %}
+                Thesis: <em>{{ article.thesis }}</em>
+            </li>
+        {% endif %}
         {% if article.advisor is defined %}
             <li class={{ li_class }}>
                 {% if fancy %}{{ fa("graduation-cap", "fa-fw", "Advisor") }}{% endif %}
                 Advisor: {{ article.advisor }}
+            </li>
+        {% endif %}
+        {% if article.sucupira is defined %}
+            <li class="list-group-item">
+                {{ fa("info-circle", "fa-fw", "Additional information") }}
+                More info:
+                <a href="https://sucupira.capes.gov.br/sucupira/public/consultas/coleta/trabalhoConclusao/viewTrabalhoConclusao.jsf?popup=true&id_trabalho={{article.sucupira}}">Sucupira platform</a>
             </li>
         {% endif %}
         {% if article.course is defined %}

--- a/about/bachelors.md
+++ b/about/bachelors.md
@@ -1,11 +1,11 @@
 ---
-title: "Cálculo do tensor gradiente gravimétrico utilizando tesseroides"
+title: <b>BSc</b> in Geophysics
+thesis: "Cálculo do tensor gradiente gravimétrico utilizando tesseroides"
 date: 2009-12-01
 start_date: 2004-03-01
 degree: BSc
 advisor: Naomi Ussami
 subject: Geophysics
-thumbnail: agu2010.png
 doi: 10.6084/m9.figshare.963547
 repository: leouieda/barchelor-thesis
 institution: Universidade de São Paulo, Brazil
@@ -18,7 +18,7 @@ layout: publication
 My Bachelor's degree in Geophysics is from the Universidade de São Paulo,
 Brazil, where I studied from 2004 until 2009.
 I did an undergraduate research project and eventually my thesis under the
-supervision of [Naomi Ussami](http://lattes.cnpq.br/6704246490515612).
+supervision of [Dr. Naomi Ussami](http://lattes.cnpq.br/6704246490515612).
 This was when I started development of the software
 [Tesseroids][/software/tesseroids] and the research that lead to the paper
 [/papers/paper-tesseroids-2016], which is the first part of my

--- a/about/masters.md
+++ b/about/masters.md
@@ -1,5 +1,6 @@
 ---
-title: "Robust 3D gravity gradient inversion by planting anomalous densities"
+title: <b>MSc</b> in Geophysics
+thesis: "Robust 3D gravity gradient inversion by planting anomalous densities"
 date: 2011-11-01
 start_date: 2010-03-01
 advisor: Valéria C. F. Barbosa
@@ -7,7 +8,6 @@ degree: MSc
 subject: Geophysics
 repository: pinga-lab/paper-planting-densities
 institution: Observatório Nacional, Brazil
-thumbnail: paper-planting-anomalous-densities-2012.png
 pdf: msc-dissertation.pdf
 layout: publication
 ---

--- a/about/phd.md
+++ b/about/phd.md
@@ -1,14 +1,15 @@
 ---
-title: "Forward modeling and inversion of gravitational fields in spherical coordinates"
+title: <b>PhD</b> in Geophysics
+thesis: "Forward modeling and inversion of gravitational fields in spherical coordinates"
 date: 2016-04-29
 start_date: 2011-11-01
 degree: PhD
 advisor: Valéria C. F. Barbosa
 subject: Geophysics
-thumbnail: paper-moho-inversion-2016.png
 repository: leouieda/phd-thesis
 institution: Observatório Nacional, Brazil
 pdf: phd-thesis.pdf
+sucupira: 3627205
 layout: publication
 ---
 


### PR DESCRIPTION
It got a bit confusing. Use the degree name instead. Set thesis title as
metadata and insert in info sidebar. This allows using the title and
thesis title in the about page as well. Strip formatting from titles
when setting the "title" in the header.
Add sucupira entry for PhD thesis.