### PR TITLE
Add more information about AOGS presentations

### DIFF
--- a/posters/aogs2018.md
+++ b/posters/aogs2018.md
@@ -14,7 +14,20 @@ layout: publication
 
 ![The poster presented at the meeting.](/images/poster-aogs2018.png)
 
-## About
+# About
+
+This is the third presentation I gave about my work on
+[GMT/Python](http://www.gmtpython.xyz/) (see my [Scipy2017
+talk][/talks/scipy2017] and my [AGU2017 poster][/posters/agu2017]).
+This is by far the nicest poster I have ever designed.
+It showcases the new support for `gmt.Figure.grdimage`, the built-in Earth
+relief datasets in GMT6, and plotting vectors with `gmt.Figure.plot`.
+I wanted to have a more sophisticated showcase of `grdimage` but I ran into
+some bugs before the conference and wasn't able to finish it in time.
+Still, I'm amazed at how few lines of code are required to make the figure in
+the poster.
+The more I get to know GMT, the more I'm impressed by how much thought and
+attention was, and still is, poured into it.
 
 I used the fonts Roboto Mono for code, Roboto for headings, and Barlow for
 other text.
@@ -25,7 +38,7 @@ The QR codes were generated using [qrencode](https://github.com/fukuchi/libqrenc
     qrencode -t EPS -o qrcode.eps URL
 
 
-## Abstract
+# Abstract
 
 The Generic Mapping Tools (GMT) are used throughout the geosciences to
 processes spatial data and create publication quality data visualizations, such
@@ -45,11 +58,12 @@ Python ecosystem through the support of common Python data types: numpy
 "ndarrays" and Pandas "DataFrames" for tabular data and xarray "Datasets" for
 grids. We have also implemented support for the Jupyter notebooks, a web-based
 interactive computing environment (an example is available at
-http://try.gmtpython.xyz). These features will help make GMT more accessible to
-students and professional geoscientists who lack an extensive background in
-Unix tools and shell scripting. GMT/Python is an open-source project in early
-stages of development. The current focus is on the implementation of a robust
-set of core routines that implement the bridge between Python and GMT. Later,
-we will expand the library to cover the entire functionality of GMT. A first
-release is predicted for the late 2018. The latest documentation and source
-code can be accessed through the website http://www.gmtpython.xyz.
+[try.gmtpython.xyz](http://try.gmtpython.xyz/). These features will help make
+GMT more accessible to students and professional geoscientists who lack an
+extensive background in Unix tools and shell scripting. GMT/Python is an
+open-source project in early stages of development. The current focus is on the
+implementation of a robust set of core routines that implement the bridge
+between Python and GMT. Later, we will expand the library to cover the entire
+functionality of GMT. A first release is predicted for the late 2018. The
+latest documentation and source code can be accessed through the website
+[www.gmtpython.xyz](http://www.gmtpython.xyz/).

--- a/talks/aogs2018.md
+++ b/talks/aogs2018.md
@@ -19,6 +19,32 @@ layout: publication
 </div>
 
 
+# About
+
+This talk is about some early results from a collaboration me and Paul have
+with [David Sandwell](http://topex.ucsd.edu/sandwell/). The project was started
+by Paul and Dave as a follow up to their [2016 paper about interpolating 2D
+vector data](https://doi.org/10.1002/2016GL070340).
+We're expanding it into 3D and ironing out some kinks in the methodology.
+I picked it up at the beginning of the year and have been slowly trying things
+out.
+It was a great chance to play with some tools from machine learning since this
+is a supervised prediction problem.
+Unlike most geophysical inversion, we're not really interested in the estimated
+parameters themselves.
+They are only a means to predict new values (on a regular grid in the case of
+gridding).
+I started implementing the tools I would need in a Python library called
+[Verde](https://github.com/fatiando/verde), which served as the basis for the
+results shown in the presentation.
+
+I made the slides using Google Docs with the Barlow font for the most part and
+EB Garamond for some of the math symbols. I used an [online Latex equation
+editor](http://www.codecogs.com/latex/eqneditor.php) to generate the equations
+as high resolution PNGs. Not ideal but it's a price I will pay for avoiding
+LibreOffice Impress.
+
+
 # Abstract
 
 


### PR DESCRIPTION
Some context to what the work is related. Renamed the talk page to 2018
(it was 2017). Good thing I haven't shared a link yet.