### PR TITLE
Hyperlink DOIs against preferred resolver

### DIFF
--- a/about/bachelors.md
+++ b/about/bachelors.md
@@ -33,7 +33,7 @@ which is the first part of my [PhD thesis][/about/phd]:
 
 You can download a PDF of my thesis (in Portuguese) from
 [figshare](http://figshare.com) at
-doi:[10.6084/m9.figshare.963547](http://dx.doi.org/10.6084/m9.figshare.963547).
+doi:[10.6084/m9.figshare.963547](https://doi.org/10.6084/m9.figshare.963547).
 
 
 # Thesis defense slides

--- a/papers/nmo-tutorial.md
+++ b/papers/nmo-tutorial.md
@@ -17,7 +17,7 @@ tags: seismic, tutorial
 # About
 
 *This is a part of The Leading Edge [tutorials
-series](https://dx.doi.org/10.1190/tle35020190.1).
+series](https://doi.org/10.1190/tle35020190.1).
 All tutorials are open-access and include open-source code examples.*
 
 The manuscript was written in [Authorea](https://www.authorea.com).

--- a/papers/paper-mag-dir-2015.md
+++ b/papers/paper-mag-dir-2015.md
@@ -32,7 +32,7 @@ for more information about using this class.
 
 This paper has undergone open peer-review.
 The original submission, reviews, and replies can be viewed at
-[doi:10.5194/npgd-1-1465-2014](http://dx.doi.org/10.5194/npgd-1-1465-2014).
+[doi:10.5194/npgd-1-1465-2014](https://doi.org/10.5194/npgd-1-1465-2014).
 
 # Abstract
 

--- a/papers/paper-moho-inversion-tesseroids-2016.md
+++ b/papers/paper-moho-inversion-tesseroids-2016.md
@@ -28,11 +28,11 @@ We applied the inversion to estimate the Moho depth for South America.
 
 The main result from this publication is the gravity-derived Moho depth model
 for South America and the differences between it and seismological estimates
-of [Assumpção et al. (2013)](http://dx.doi.org/10.1016/j.tecto.2012.11.014).
+of [Assumpção et al. (2013)](https://doi.org/10.1016/j.tecto.2012.11.014).
 These differences allow us to know where the gravity-derived model can be trusted and where there might be unaccounted sources in the gravity data.
 
 You can **download** the model results, source code, and input data from
-doi:[10.6084/m9.figshare.3987267](https://dx.doi.org/10.6084/m9.figshare.3987267)
+doi:[10.6084/m9.figshare.3987267](https://doi.org/10.6084/m9.figshare.3987267)
 
 ![The estimated Moho depth for South America and differences with seismological estimates.](/images/south-american-moho-gravity-inversion.png)
 \[[high resolution version](https://raw.githubusercontent.com/pinga-lab/paper-moho-inversion-tesseroids/master/model/south-american-moho.png)\]

--- a/papers/paper-planting-anomalous-densities-2012.md
+++ b/papers/paper-planting-anomalous-densities-2012.md
@@ -30,7 +30,7 @@ of the library.
 The following is an animation of the growth algorithm
 during the inversion of synthetic data.
 The video is available at [figshare](http://figshare.com/):
-[10.6084/m9.figshare.91469](http://dx.doi.org/10.6084/m9.figshare.91469)
+[10.6084/m9.figshare.91469](https://doi.org/10.6084/m9.figshare.91469)
 
 <div class="embed-responsive embed-responsive-16by9">
 <iframe src="https://widgets.figshare.com/articles/91469/embed?show_title=0"

--- a/papers/paper-tle-euler-tutorial-2014.md
+++ b/papers/paper-tle-euler-tutorial-2014.md
@@ -22,7 +22,7 @@ section in [The Leading Edge](http://library.seg.org/journal/leedff),
 started by Matt Hall of [Agile Geoscience](http://agilegeoscience.com/).
 All tutorials are Open-Access and include open-source code examples.
 Read the
-[February 2016 tutorial](http://dx.doi.org/10.1190/tle35020190.1) by Matt
+[February 2016 tutorial](https://doi.org/10.1190/tle35020190.1) by Matt
 for an introduction to the tutorial series
 and what you need to know to get started running the code in them.
 The article is also available at the
@@ -48,7 +48,7 @@ usefulness and, most importantly, call attention to some pitfalls encountered
 in the interpretation of the results. The code and synthetic data required to
 reproduce our results and figures can be found in the accompanying IPython
 notebooks ([ipython.org/notebook](http://ipython.org/notebook))
-at [dx.doi.org/10.6084/m9.figshare.923450](http://dx.doi.org/10.6084/m9.figshare.923450)
+at [dx.doi.org/10.6084/m9.figshare.923450](https://doi.org/10.6084/m9.figshare.923450)
 or [github.com/pinga-lab/paper-tle-euler-tutorial](https://github.com/pinga-lab/paper-tle-euler-tutorial).
 The notebooks also expand the
 analysis presented here. We encourage you to download the data and try it on

--- a/posters/goce2011.md
+++ b/posters/goce2011.md
@@ -20,10 +20,10 @@ tags: tesseroids, gravity
 ![The poster](/images/poster-goce2011.png)
 
 This poster and conference proceedings present the results and methods after
-the [1.0 release](http://dx.doi.org/10.5281/zenodo.15803) of my open-source
+the [1.0 release](https://doi.org/10.5281/zenodo.15803) of my open-source
 software [/software/tesseroids].
 Version 1.0 was a complete re-write of the
-[original Python code](http://dx.doi.org/10.5281/zenodo.15804) in the C
+[original Python code](https://doi.org/10.5281/zenodo.15804) in the C
 language.
 This work was made possible by professor
 [Carla Braitenberg](http://www.lithoflex.org/).

--- a/software/tesseroids.md
+++ b/software/tesseroids.md
@@ -25,7 +25,7 @@ I started working on *Tesseroids* in 2008 for my
 Since then, the software has been through many revisions.
 
 The paper "[/papers/paper-tesseroids-2016]" describes the algorithms behind
-[version 1.2.0](http://dx.doi.org/10.5281/zenodo.16033) of the software.
+[version 1.2.0](https://doi.org/10.5281/zenodo.16033) of the software.
 This paper became a chapter of [my PhD thesis][/about/phd].
 
 # Presentations


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). Yes, a bit ironic, but it's now [encrypted](https://www.ssllabs.com/ssltest/analyze.html?d=doi.org) and the old links with the `dx` subdomain continue to work.

So, there is no urgent need to do anything, but nonetheless, I'd like to suggest to hereby update all static DOIs.

Cheers!