### PR TITLE
Single column layout with narrower text

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -56,6 +56,34 @@
 
     {% include 'nav.html' %}
 
+    {% block banner %}
+        {% if this.banner is defined %}
+            {% if this.banner_position is defined %}
+                {% set position = this.banner_position %}
+            {% else %}
+                {% set position = "center" %}
+            {% endif %}
+            {% if this.banner_description is defined %}
+                {% set title = this.banner_description %}
+            {% else %}
+                {% set title = "" %}
+            {% endif %}
+            <div class="banner"
+                 title="{{ title }}"
+                 style="background-image: url(/{{ site.banner_path }}/{{ this.banner }}); background-position: {{position}};">
+                {% if this.description is defined %}
+                    <div class="banner-text" title="{{ title }}">
+                        {{ this.description }}
+                    </div>
+                {% else %}
+                    <h1 class="banner-title" title="{{ title }}">
+                        {{ this.title }}
+                    </h1>
+                {% endif %}
+            </div>
+        {% endif %}
+    {% endblock %}
+
     {% block body %}
     {% endblock %}
 

--- a/_layouts/blog.html
+++ b/_layouts/blog.html
@@ -1,10 +1,8 @@
-{% extends "page.html" %}
+{% extends "index.html" %}
 {% from "utils.html" import make_index %}
 
-{% block content %}
+{% block index %}
 
-{{ super() }}
-
-{{ make_index(this.content, site, date=true, year_only=false, show_oa=false) }}
+    {{ make_index(this.content, site, date=true, year_only=false, show_oa=false) }}
 
 {% endblock %}

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -17,13 +17,15 @@
 {% endblock %}
 
 
-{% block content %}
+{% block body %}
 
-    {{ this.body }}
+    <div class="container">
+        {{ this.body }}
 
-    {% for category in this.content %}
-        <h2 class="category-header text-center"><a href="{{ category.url }}">{{ category.title }}  »</a></h2>
-        {{ make_index(category.content, site, date=false, hr=false, ncards=4) }}
-    {% endfor %}
+        {% for category in this.content %}
+            <h2 class="category-header text-center"><a href="{{ category.url }}">{{ category.title }}  »</a></h2>
+            {{ make_index(category.content, site, date=false, hr=false, ncards=4) }}
+        {% endfor %}
+    </div>
 
 {% endblock %}

--- a/_layouts/index.html
+++ b/_layouts/index.html
@@ -1,10 +1,19 @@
 {% extends "page.html" %}
 {% from "utils.html" import make_index %}
 
-{% block content %}
+{% block body %}
 
-{{ super() }}
+    <div class="container">
+        {% if not this.banner is defined %}
+            <h1>{{ this.title }}</h1>
+        {% endif %}
+        {% if this.body is defined %}
+            {{ this.body }}
+        {% endif %}
 
-{{ make_index(this.content, site, date=false, show_oa=true) }}
+        {% block index %}
+            {{ make_index(this.content, site, date=false, show_oa=true) }}
+        {% endblock %}
+    </div>
 
 {% endblock %}

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -49,34 +49,7 @@
 
 {% block body %}
 
-    {% block banner %}
-        {% if this.banner is defined %}
-            {% if this.banner_position is defined %}
-                {% set position = this.banner_position %}
-            {% else %}
-                {% set position = "center" %}
-            {% endif %}
-            {% if this.banner_description is defined %}
-                {% set title = this.banner_description %}
-            {% else %}
-                {% set title = "" %}
-            {% endif %}
-            <div class="banner"
-                 title="{{ title }}"
-                 style="background-image: url(/{{ site.banner_path }}/{{ this.banner }}); background-position: {{position}};">
-                {% if this.description is defined %}
-                    <div class="banner-text" title="{{ title }}">
-                        {{ this.description }}
-                    </div>
-                {% else %}
-                    <h1 class="banner-title" title="{{ title }}">
-                        {{ this.title }}
-                    </h1>
-                {% endif %}
-            </div>
-        {% endif %}
-    {% endblock %}
-
+    {# The content class limits the size of the container #}
     <div class="container content">
         {% block breadcrumbs %}
         {% endblock %}

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -1,49 +1,34 @@
 {% extends "publication.html" %}
-{% from "utils.html" import feedback, insert_thumbnail, make_tags, fa, make_side_index, pub_info_icon %}
+{% from "utils.html" import feedback, insert_thumbnail, make_tags, fa, make_index, pub_info_icon, related_pages, disqus %}
 
 
 {% block content %}
 
-    <div class="row">
-        <div class="col-md-9">
+    <h1>{{ this.title }}</h1>
 
-            <h1>{{ this.title }}</h1>
+    <ul class="fa-ul">
+        <li class="post-date">
+            {{ pub_info_icon("fa fa-calendar", "date") }}
+            {{ this.date.strftime(' %d %B %Y') }}
+        </li>
+        {% if this.tags is defined %}
+            <li>
+                {{ pub_info_icon("fa fa-tags", "tags") }}
+                {{ make_tags(this.tags) }}
+            </li>
+        {% endif %}
+    </ul>
 
-            <ul class="fa-ul">
-                <li class="post-date">
-                    {{ pub_info_icon("fa fa-calendar", "date") }}
-                    {{ this.date.strftime(' %d %B %Y') }}
-                </li>
-                {% if this.tags is defined %}
-                    <li>
-                        {{ pub_info_icon("fa fa-tags", "tags") }}
-                        {{ make_tags(this.tags) }}
-                    </li>
-                {% endif %}
-            </ul>
+    {{ this.body }}
 
-            <div class="content">
-                {{ this.body }}
-            </div>
+    {{ feedback(this, site, fancy=true) }}
 
-            {{ feedback(this, site, fancy=true) }}
+    <h2>More from the blog</h2>
+    {% set posts = site.reflinks['/blog'].content|sort(attribute='date', reverse=true) %}
+    {{ make_index(posts, site, date=true, year_only=false, ncards=4, hr=false) }}
 
-        </div>
+    {{ related_pages(this, site) }}
 
-        <div class="col-md-1">
-        </div>
-
-        <div class="col-md-2 sidebar">
-            <h2>Blog</h2>
-            {% set posts = site.reflinks['/blog'].content|sort(attribute='date', reverse=true) %}
-            {{ make_side_index(posts, site, date=true, year_only=false, ncards=3) }}
-
-            {% set pages = this|related(site)|sort(attribute='date', reverse=true) %}
-            {% if pages %}
-                <h2>Related</h2>
-                {{ make_side_index(pages, site, date=true, year_only=true, ncards=3) }}
-            {% endif %}
-        </div>
-    </div>
+    {{ disqus(this, site) }}
 
 {% endblock %}

--- a/_layouts/publication.html
+++ b/_layouts/publication.html
@@ -1,6 +1,7 @@
 {% extends "page.html" %}
 {% from "utils.html" import fa, ai, get_authors, pub_alerts, pub_info,
-   show_alm, feedback, insert_thumbnail, make_breadcrumbs, make_side_index %}
+   article_level_metrics, feedback, insert_thumbnail, make_breadcrumbs, related_pages,
+   disqus %}
 
 
 {% block breadcrumbs %}
@@ -10,58 +11,38 @@
 
 {% block content %}
 
-    <div class="row">
+    <h1>{{ this.title }}</h1>
 
-        <div class="col-md-9">
-            <h1>{{ this.title }}</h1>
-
-            {% if this.author is defined %}
-                <p class="pub-date-author">
-                    {{ get_authors(this, site) }}
-                    {% if this.date is defined %}
-                        <span class="post-date">({{ this.date.year }})</span>
-                    {% endif %}
-                </p>
+    {% if this.author is defined %}
+        <p class="pub-date-author">
+            {{ get_authors(this, site) }}
+            {% if this.date is defined %}
+                <span class="post-date">({{ this.date.year }})</span>
             {% endif %}
+        </p>
+    {% endif %}
 
-            {{ pub_alerts(this, fancy=true) }}
+    {{ pub_alerts(this, fancy=true) }}
 
-            <h2>Info</h2>
+    <h2>Info</h2>
 
-            <div class="info">
-                {{ pub_info(this, fancy=true) }}
-            </div>
-
-            {{ this.body }}
-
-            {% if this.citation is defined %}
-                <h2>Citation</h2>
-                <p>{{this.citation}}</p>
-            {% endif %}
-        </div>
-
-        <div class="col-md-1">
-        </div>
-
-        <div class="col-md-2 sidebar">
-            {{ show_alm(this) }}
-
-            {% set pages = this|related(site)|sort(attribute='date', reverse=true) %}
-            {% if pages %}
-                <h2>Related</h2>
-                {{ make_side_index(pages, site, date=true, year_only=true, ncards=4) }}
-            {% endif %}
-        </div>
-
+    <div class="info">
+        {{ pub_info(this, fancy=true) }}
     </div>
 
-    {# Separate this so that the sidebar collapses above the comments #}
-    <div class="row">
-        <div class="col-md-9">
-            {{ feedback(this, site, fancy=true) }}
-        </div>
-        <div class="col-md-3">
-        </div>
-    </div>
+    {{ this.body }}
+
+    {% if this.citation is defined %}
+        <h2>Citation</h2>
+        <p>{{this.citation}}</p>
+    {% endif %}
+
+    {{ article_level_metrics(this) }}
+
+    {{ related_pages(this, site) }}
+
+    {{ feedback(this, site, fancy=true) }}
+
+    {{ disqus(this, site) }}
 
 {% endblock %}

--- a/_layouts/teaching.html
+++ b/_layouts/teaching.html
@@ -1,14 +1,12 @@
-{% extends "page.html" %}
+{% extends "index.html" %}
 
 {% from "utils.html" import make_index %}
 
-{% block content %}
+{% block index %}
 
-{{ super() }}
-
-{% for group in this.content|groupby("course")|reverse() %}
-    <h2>{{group.grouper|capitalize()}} Courses</h2>
-    {{ make_index(group.list, site, date=true, year_only=true, hr=false) }}
-{% endfor %}
+    {% for group in this.content|groupby("course")|reverse() %}
+        <h2>{{group.grouper|capitalize()}} Courses</h2>
+        {{ make_index(group.list, site, date=true, year_only=true, hr=false) }}
+    {% endfor %}
 
 {% endblock %}

--- a/_layouts/utils.html
+++ b/_layouts/utils.html
@@ -422,6 +422,16 @@
 {%- endmacro -%}
 
 
+{%- macro related_pages(article, site) -%}
+{# Create an index section with pages that share a tag with this one #}
+    {% set pages = article|related(site)|sort(attribute='date', reverse=true) %}
+    {% if pages %}
+        <h2>Related pages</h2>
+        {{ make_index(pages, site, date=true, year_only=true, ncards=4, hr=false) }}
+    {% endif %}
+{%- endmacro -%}
+
+
 {%- macro altmetric_badge(doi, title) -%}
 {# Insert the altmetric badge if "doi" is a valid doi. #}
     {%- if "doi.org/" in make_metadata_link(doi) -%}
@@ -432,26 +442,38 @@
 {%- endmacro -%}
 
 
-{%- macro show_alm(article) -%}
-{# Create the article level metrics side bar #}
+{%- macro article_level_metrics(article) -%}
+{# Create the article level metrics section #}
     {%- if article.alm is defined and article.alm -%}
-        <h2>Metrics</h2>
+        <h2>Article Level Metrics</h2>
+
+        <div class="row">
 
         {%- if article.doi is defined -%}
+            <div class="col-sm-3">
             {{ altmetric_badge(article.doi, "Main article") }}
+            </div>
         {%- endif -%}
 
         {%- if article.supplement is defined -%}
+            <div class="col-sm-3">
             {{ altmetric_badge(article.supplement, "Data/Supplement") }}
+            </div>
         {%- endif -%}
 
         {%- if article.poster is defined -%}
+            <div class="col-sm-3">
             {{ altmetric_badge(article.poster, "Poster") }}
+            </div>
         {%- endif -%}
 
         {%- if article.slides is defined -%}
+            <div class="col-sm-3">
             {{ altmetric_badge(article.slides, "Slides") }}
+            </div>
         {%- endif -%}
+
+        </div>
     {%- endif -%}
 {%- endmacro -%}
 
@@ -471,9 +493,8 @@
 
 
 {%- macro feedback(post, site, fancy=true) -%}
-{# Make the feedback request boxes and Disqus comments section #}
+{# Make the feedback request boxes #}
     <hr>
-
     {%- if fancy -%}
     <div class="panel panel-default feedback">
         <div class="panel-body">
@@ -510,8 +531,12 @@
     {%- else -%}
         </p>
     {%- endif -%}
+{%- endmacro -%}
 
-    <!-- The Disqus comments code -->
+
+{%- macro disqus(post, site) -%}
+{# Embed the Disqus comments in the page #}
+    <!-- Disqus -->
     <div id="disqus_thread"></div>
     <script>
         var disqus_config = function () {
@@ -526,5 +551,4 @@
         })();
     </script>
     <noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript">comments powered by Disqus.</a></noscript>
-
 {%- endmacro -%}

--- a/css/style.css
+++ b/css/style.css
@@ -352,3 +352,9 @@ img {
 .info {
     font-size: 0.9em;
 }
+
+@media (min-width: 1200px) {
+    .content {
+        width: 900px;
+    }
+}


### PR DESCRIPTION
Remove the side columns from publications and blog posts. Instead, put
them at the bottom of the page to avoid distractions. Use a media query
to make the content column narrower or lager screens for better
readability. Use multiple columns for ALM badges.