### PR TITLE
Fix broken template for tag pages

### DIFF
--- a/_layouts/index.html
+++ b/_layouts/index.html
@@ -4,15 +4,17 @@
 {% block body %}
 
     <div class="container">
-        {% if not this.banner is defined %}
-            <h1>{{ this.title }}</h1>
-        {% endif %}
-        {% if this.body is defined %}
-            {{ this.body }}
-        {% endif %}
+        {% block content %}
+            {% if not this.banner is defined %}
+                <h1>{{ this.title }}</h1>
+            {% endif %}
+            {% if this.body is defined %}
+                {{ this.body }}
+            {% endif %}
 
-        {% block index %}
-            {{ make_index(this.content, site, date=false, show_oa=true) }}
+            {% block index %}
+                {{ make_index(this.content, site, date=false, show_oa=true) }}
+            {% endblock %}
         {% endblock %}
     </div>
 

--- a/_layouts/tag.html
+++ b/_layouts/tag.html
@@ -1,4 +1,4 @@
-{% extends "index.html" %}
+{% extends "page.html" %}
 {% from "utils.html" import make_index, make_tag, fa %}
 
 
@@ -18,10 +18,11 @@
 
 {% block content %}
     <h1>{{ fa('tags') }} {{ make_tag(this.title, link=false) }}</h1>
+    {{ make_index(this.content, site, date=true, year_only=true, show_oa=true) }}
     {# The type attribute is define by a hook in _python/hooks.py #}
-    {% for group in this.content|groupby("type") %}
+    {# {% for group in this.content|groupby("type") %}
         {% set category = site.reflinks[group.grouper] %}
         <h2 class="category-header"><a href="{{ category.url }}">{{ category.title }}  »</a></h2>
         {{ make_index(group.list, site, date=true, year_only=true, show_oa=true, hr=false) }}
-    {% endfor %}
+    {% endfor %} #}
 {% endblock %}


### PR DESCRIPTION
They inherited from index.html and defined the content block, which
didn't exist anymore. Add it back to index but tag.html inherits from
page.html now.