### PR TITLE
Correctly set altmetric badge width to auto

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -241,9 +241,8 @@ img {
     padding: 0;
 }
 
-.altmetric-embed img + .__dimensions_badge_embed__ img {
+.altmetric-embed img {
     width: auto;
-    height: 100%;
 }
 
 .altmetric-badge-group {


### PR DESCRIPTION
Was setting it wrong in the css so the badge was deformed on some
screens